### PR TITLE
add(tokens):feedback.loader.md/lg

### DIFF
--- a/packages/figma-design-tokens/input/BLR-tokens.json
+++ b/packages/figma-design-tokens/input/BLR-tokens.json
@@ -2048,6 +2048,10 @@
           }
         },
         "md": {
+          "padding": {
+            "value": "{core.rem-dimensions.3}",
+            "type": "spacing"
+          },
           "sizing": {
             "value": "{core.rem-dimensions.24}",
             "type": "sizing"
@@ -2090,6 +2094,10 @@
           }
         },
         "lg": {
+          "padding": {
+            "value": "{core.rem-dimensions.2}",
+            "type": "spacing"
+          },
           "background": {
             "default": {
               "value": {


### PR DESCRIPTION
hey @davidken91 , I just figured, that I missed to add the padding tokens for md and lg. Here they are.