### PR TITLE
fix: removes transform to rem

### DIFF
--- a/packages/figma-design-tokens/config/style-dictionary.config.js
+++ b/packages/figma-design-tokens/config/style-dictionary.config.js
@@ -69,7 +69,6 @@ module.exports = {
         'transform/size/px',
         'transform/strReplace',
         'transform/font-weight',
-        'transform/font-to-rem',
       ],
       prefix: 'blr',
       buildPath: '../ui-library/src/foundation/_tokens-generated/',


### PR DESCRIPTION
Font Sizes are already provided as rem value, so I removed the transform that calculates a pixel value to rem value