### PR TITLE
fix: runs action on branches with design/*

### DIFF
--- a/.github/workflows/build-design-tokens.yml
+++ b/.github/workflows/build-design-tokens.yml
@@ -3,10 +3,10 @@ name: Build design tokens
 on:
   push:
     branches:
-      - design
+      - 'design/*'
   pull_request:
     branches:
-      - design
+      - 'design/*'
 
 jobs:
   build:


### PR DESCRIPTION
According to the branching strategy discussed with design, we changed the condition when the "Build design tokens" task is run