### PR TITLE
fix(ui-library): hide canvas preview in stories

### DIFF
--- a/packages/ui-library/src/components/icon-button/index.stories.ts
+++ b/packages/ui-library/src/components/icon-button/index.stories.ts
@@ -23,6 +23,12 @@ export default {
       control: { type: 'select' },
     },
   },
+  parameters: {
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+    viewMode: 'docs',
+  },
 };
 
 export const BlrIconButton = ({

--- a/packages/ui-library/src/components/icon-link/index.stories.ts
+++ b/packages/ui-library/src/components/icon-link/index.stories.ts
@@ -23,6 +23,12 @@ export default {
       control: { type: 'select' },
     },
   },
+  parameters: {
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+    viewMode: 'docs',
+  },
 };
 
 export const BlrIconLink = ({

--- a/packages/ui-library/src/components/icon/index.stories.ts
+++ b/packages/ui-library/src/components/icon/index.stories.ts
@@ -15,6 +15,12 @@ export default {
       control: { type: 'select' },
     },
   },
+  parameters: {
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+    viewMode: 'docs',
+  },
 };
 
 const allIcons = getIconName(IconKeys);

--- a/packages/ui-library/src/components/link/index.stories.ts
+++ b/packages/ui-library/src/components/link/index.stories.ts
@@ -35,6 +35,12 @@ export default {
       control: { type: 'select' },
     },
   },
+  parameters: {
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+    viewMode: 'docs',
+  },
 };
 export const BlrLink = ({
   label,

--- a/packages/ui-library/src/components/loader/index.stories.ts
+++ b/packages/ui-library/src/components/loader/index.stories.ts
@@ -15,6 +15,12 @@ export default {
       control: { type: 'select' },
     },
   },
+  parameters: {
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+    viewMode: 'docs',
+  },
 };
 
 export const BlrLoader = ({ size, variant, loadingStatus }: BlrLoaderClass) =>

--- a/packages/ui-library/src/components/text-button/index.stories.ts
+++ b/packages/ui-library/src/components/text-button/index.stories.ts
@@ -27,6 +27,12 @@ export default {
       control: { type: 'select' },
     },
   },
+  parameters: {
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+    viewMode: 'docs',
+  },
 };
 
 export const BlrTextButton = ({

--- a/packages/ui-library/src/components/text-input/index.stories.ts
+++ b/packages/ui-library/src/components/text-input/index.stories.ts
@@ -27,6 +27,12 @@ export default {
       control: { type: 'select' },
     },
   },
+  parameters: {
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+    viewMode: 'docs',
+  },
 };
 
 export const BlrTextInput = ({


### PR DESCRIPTION
The Canvas preview recreates components on each property change and destroy the web component lifecycle.
Maybe the easiest approach is to simply hide that view? 