### PR TITLE
Design/fix selects

### DIFF
--- a/packages/figma-design-tokens/input/tokens/semantics/BLR_CMP.json
+++ b/packages/figma-design-tokens/input/tokens/semantics/BLR_CMP.json
@@ -1820,6 +1820,26 @@
           "value": "{core.dimensionPX.12}",
           "type": "spacing"
         }
+      },
+      "MD": {
+        "InputPadding": {
+          "value": "{core.dimensionREM.8} {core.dimensionPX.40} {core.dimensionREM.8} {core.dimensionPX.12}",
+          "type": "spacing"
+        },
+        "IconPaddingRight": {
+          "value": "{core.dimensionPX.12}",
+          "type": "spacing"
+        }
+      },
+      "LG": {
+        "InputPadding": {
+          "value": "{core.dimensionREM.12} {core.dimensionPX.48} {core.dimensionREM.12} {core.dimensionPX.16}",
+          "type": "spacing"
+        },
+        "IconPaddingRight": {
+          "value": "{core.dimensionPX.16}",
+          "type": "spacing"
+        }
       }
     }
   },


### PR DESCRIPTION
This PR adds and spacing tokens on BLR_CMP: Forms.Select.<...>
It enables us to position the chevron/error icon absolute.
Apply InputPadding on an inputWrapper
Appyl IconPaddingRight on a wrapper of the chevron/error icon