### PR TITLE
fix(ui-library): disabled a stylelint rule for radio.css

### DIFF
--- a/packages/ui-library/.stylelintrc.json
+++ b/packages/ui-library/.stylelintrc.json
@@ -5,6 +5,7 @@
     "comment-empty-line-before": null,
     "at-rule-empty-line-before": null,
     "declaration-empty-line-before": null,
+    "declaration-colon-newline-after": null,
     "property-no-vendor-prefix": null,
     "alpha-value-notation": null,
     "value-keyword-case": ["lower", { "ignoreProperties": ["--font-family-sans"], "ignoreKeywords": ["/POSTCSS/"] }],


### PR DESCRIPTION
hey folks,

the radio.css.ts has some linebreaks with that calc functions which are made by prettier and hated by stylelint.
this fixes that :)
