### PR TITLE
css fixes for FF

### DIFF
--- a/packages/ui-library/.stylelintrc.json
+++ b/packages/ui-library/.stylelintrc.json
@@ -12,7 +12,8 @@
     "selector-class-pattern": null,
     "no-descending-specificity": null,
     "value-no-vendor-prefix": null,
-    "font-family-name-quotes": null
+    "font-family-name-quotes": null,
+    "selector-not-notation": null
   },
   "ignoreShorthands": ["outline"]
 }

--- a/packages/ui-library/src/foundation/component-tokens/checkbox.css.js
+++ b/packages/ui-library/src/foundation/component-tokens/checkbox.css.js
@@ -187,7 +187,7 @@ export const { tokenizedLight: checkboxLight, tokenizedDark: checkboxDark } = re
                 border-color: ${Checkbox.Control.Background.Selected.Stroke.ReadOnly};
               }
               &:hover {
-                &:not(:disabled, [readonly]) {
+                &:not(:disabled):not([readonly]) {
                   background-color: ${Checkbox.Control.Background.Selected.Fill.Hover};
                   border-color: ${Checkbox.Control.Background.Selected.Stroke.Hover};
                 }
@@ -202,13 +202,13 @@ export const { tokenizedLight: checkboxLight, tokenizedDark: checkboxDark } = re
                 background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none"%3E%3Cpath d="M3.35834 8.9759L5.39724 10.9618C5.65804 11.2159 6.07374 11.2159 6.33454 10.9618L12.7617 4.70166" stroke="white" stroke-width="0.671667" stroke-linecap="round" stroke-linejoin="round" /%3E%3C/svg%3E');
               }
               &:hover {
-                &:not(:disabled, [readonly]) {
+                &:not(:disabled):not([readonly]) {
                   background-color: ${Checkbox.Control.Background.Selected.Fill.Hover};
                   border-color: ${Checkbox.Control.Background.Selected.Stroke.Hover};
                 }
               }
               &:active {
-                &:not(:disabled, [readonly]) {
+                &:not(:disabled):not([readonly]) {
                   background-color: ${Checkbox.Control.Background.Selected.Fill.Pressed};
                   border-color: ${Checkbox.Control.Background.Selected.Stroke.Pressed};
                 }
@@ -243,13 +243,13 @@ export const { tokenizedLight: checkboxLight, tokenizedDark: checkboxDark } = re
               border-color: ${Checkbox.Control.Background.Unselected.Stroke.Disabled};
             }
             &:hover {
-              &:(:disabled, [readonly]) {
+              &:(:disabled):not([readonly]) {
                 background-color: ${Checkbox.Control.Background.Unselected.Fill.Hover};
                 border-color: ${Checkbox.Control.Background.Unselected.Stroke.Hover};
               }
             }
             &:active {
-              &:not(:disabled, [readonly]) {
+              &:not(:disabled):not([readonly]) {
                 background-color: ${Checkbox.Control.Background.Unselected.Fill.Pressed};
                 border-color: ${Checkbox.Control.Background.Unselected.Stroke.Pressed};
               }
@@ -267,13 +267,13 @@ export const { tokenizedLight: checkboxLight, tokenizedDark: checkboxDark } = re
               background-color: ${Checkbox.Control.Background.Selected.Fill.Rest};
               border-color: ${Checkbox.Control.Background.Selected.Stroke.Rest};
               &:hover {
-                &:not(:disabled, [readonly]) {
+                &:not(:disabled):not([readonly]) {
                   background-color: ${Checkbox.Control.Background.Selected.Fill.Hover};
                   border-color: ${Checkbox.Control.Background.Selected.Stroke.Hover};
                 }
               }
               &:active {
-                &:not(:disabled, [readonly]) {
+                &:not(:disabled):not([readonly]) {
                   background-color: ${Checkbox.Control.Background.Selected.Fill.Pressed};
                   border-color: ${Checkbox.Control.Background.Selected.Stroke.Pressed};
                 }

--- a/packages/ui-library/src/foundation/component-tokens/radio.css.js
+++ b/packages/ui-library/src/foundation/component-tokens/radio.css.js
@@ -218,7 +218,7 @@ export const { tokenizedLight: radioLight, tokenizedDark: radioDark } = renderTh
             }
 
             &:hover {
-              &:not(.disabled, .readonly) {
+              &:not(.disabled):not(.readonly) {
                 background-color: ${Radio.Control.Background.Unselected.Fill.Hover};
                 width: ${Radio.Control.Background.Unselected.Hover};
                 height: ${Radio.Control.Background.Unselected.Hover};
@@ -230,7 +230,7 @@ export const { tokenizedLight: radioLight, tokenizedDark: radioDark } = renderTh
                   height: ${Radio.Control.Foreground.Unselected.Hover};
                 }
 
-                + .label-wrapper {
+                & + .label-wrapper {
                   .blr-form-label-inline {
                     color: ${LabelNextToControl.Hover};
                   }
@@ -239,7 +239,7 @@ export const { tokenizedLight: radioLight, tokenizedDark: radioDark } = renderTh
             }
 
             &:active {
-              &:not(.disabled, .readonly) {
+              &:not(.disabled):not(.readonly) {
                 background-color: ${Radio.Control.Background.Unselected.Fill.Pressed};
                 width: ${Radio.Control.Background.Unselected.Pressed};
                 height: ${Radio.Control.Background.Unselected.Pressed};
@@ -251,7 +251,7 @@ export const { tokenizedLight: radioLight, tokenizedDark: radioDark } = renderTh
                   height: ${Radio.Control.Foreground.Unselected.Pressed};
                 }
 
-                + .label-wrapper {
+                & + .label-wrapper {
                   .blr-form-label-inline {
                     color: ${LabelNextToControl.Pressed};
                   }
@@ -273,7 +273,7 @@ export const { tokenizedLight: radioLight, tokenizedDark: radioDark } = renderTh
                 height: ${Radio.Control.Foreground.Unselected.Focus};
               }
 
-              + .label-wrapper {
+              & + .label-wrapper {
                 .blr-form-label-inline {
                   color: ${LabelNextToControl.Focus};
                 }
@@ -357,7 +357,7 @@ export const { tokenizedLight: radioLight, tokenizedDark: radioDark } = renderTh
                 height: ${Radio.Control.Foreground.Unselected.Disabled};
               }
 
-              + .label-wrapper {
+              & + .label-wrapper {
                 .blr-form-label-inline {
                   cursor: not-allowed;
                   color: ${LabelNextToControl.Disabled};
@@ -379,7 +379,7 @@ export const { tokenizedLight: radioLight, tokenizedDark: radioDark } = renderTh
               height: ${Radio.Control.Foreground.Unselected.Error};
             }
 
-            + .label-wrapper {
+            & + .label-wrapper {
               .blr-form-label-inline {
                 color: ${LabelNextToControl.Error};
               }
@@ -400,7 +400,7 @@ export const { tokenizedLight: radioLight, tokenizedDark: radioDark } = renderTh
               height: ${Radio.Control.Foreground.Unselected.Disabled};
             }
 
-            + .label-wrapper {
+            & + .label-wrapper {
               .blr-form-label-inline {
                 color: ${LabelNextToControl.Disabled};
               }
@@ -421,7 +421,7 @@ export const { tokenizedLight: radioLight, tokenizedDark: radioDark } = renderTh
               height: ${Radio.Control.Foreground.Unselected.ReadOnly};
             }
 
-            + .label-wrapper {
+            & + .label-wrapper {
               .blr-form-label-inline {
                 color: ${LabelNextToControl.ReadOnly};
               }

--- a/packages/ui-library/src/foundation/component-tokens/slider-legend.css.js
+++ b/packages/ui-library/src/foundation/component-tokens/slider-legend.css.js
@@ -15,7 +15,7 @@ export const { tokenizedLight: sliderLight, tokenizedDark: sliderDark } = render
       justify-content: space-between;
       gap: 20px;
 
-      > .min-max-value {
+      & > .min-max-value {
         font-family: ${Forms.Slider.Legend.Typography.fontFamily}, Arial, sans-serif;
         font-size: ${Forms.Slider.Legend.Typography.fontSize};
         font-weight: ${Forms.Slider.Legend.Typography.fontWeight};
@@ -23,10 +23,10 @@ export const { tokenizedLight: sliderLight, tokenizedDark: sliderDark } = render
         color: ${Forms.Slider.Legend.Color.Default};
       }
 
-      > .input-row {
+      & > .input-row {
         width: 100%;
 
-        > .range-wrapper {
+        & > .range-wrapper {
           position: relative;
           width: 100%;
         }
@@ -152,7 +152,7 @@ export const { tokenizedLight: sliderLight, tokenizedDark: sliderDark } = render
       top: 5px;
       width: 100%;
 
-      > .range__bar-row {
+      & > .range__bar-row {
         display: flex;
         justify-content: space-between;
       }
@@ -169,7 +169,7 @@ export const { tokenizedLight: sliderLight, tokenizedDark: sliderDark } = render
     }
 
     .range__container {
-      > .range__pip {
+      & > .range__pip {
         width: ${Forms.Slider.TickMark.Sizing};
         height: ${Forms.Slider.TickMark.Sizing};
         margin: 0 0 10px;
@@ -200,7 +200,7 @@ export const { tokenizedLight: sliderLight, tokenizedDark: sliderDark } = render
         }
       }
 
-      > .range__point {
+      & > .range__point {
         font-family: ${Forms.Slider.Legend.Typography.fontFamily}, Arial, sans-serif;
         font-size: ${Forms.Slider.Legend.Typography.fontSize};
         font-weight: ${Forms.Slider.Legend.Typography.fontWeight};

--- a/packages/ui-library/src/foundation/component-tokens/slider.css.js
+++ b/packages/ui-library/src/foundation/component-tokens/slider.css.js
@@ -19,12 +19,12 @@ export const { tokenizedLight: sliderLight, tokenizedDark: sliderDark } = render
         justify-content: space-between;
         gap: 20px;
 
-        > .range-wrapper {
+        & > .range-wrapper {
           width: 100%;
           position: relative;
           min-height: 10px;
 
-          > input[type="range"] {
+          & > input[type="range"] {
             position: absolute;
             width: 100%;
             height: 5px;
@@ -121,7 +121,7 @@ export const { tokenizedLight: sliderLight, tokenizedDark: sliderDark } = render
             }
           }
 
-          > .tooltip {
+          & > .tooltip {
             position: absolute;
             bottom: 15px;
             display: inline-block;
@@ -136,7 +136,7 @@ export const { tokenizedLight: sliderLight, tokenizedDark: sliderDark } = render
           }
         }
 
-        > .inline-legend {
+        & > .inline-legend {
           font-family: ${Forms.Slider.Legend.Typography.fontFamily}, Arial, sans-serif;
           font-size: ${Forms.Slider.Legend.Typography.fontSize};
           font-weight: ${Forms.Slider.Legend.Typography.fontWeight};
@@ -145,12 +145,12 @@ export const { tokenizedLight: sliderLight, tokenizedDark: sliderDark } = render
           word-wrap: normal;
           white-space: nowrap;
 
-          > p {
+          & > p {
             margin: 0;
           }
         }
 
-        > .inline-legend-disabled {
+        & > .inline-legend-disabled {
           color: ${Forms.Slider.Legend.Color.Disabled};
         }
       }

--- a/packages/ui-library/src/foundation/component-tokens/toggleSwitch.css.js
+++ b/packages/ui-library/src/foundation/component-tokens/toggleSwitch.css.js
@@ -19,21 +19,21 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
           align-items: center;
         }
 
-        > .toggle-content-col {
+        & > .toggle-content-col {
           display: flex;
           flex-direction: column;
 
-          > .blr-form-label-inline {
+          & > .blr-form-label-inline {
             color: ${LabelNextToControl.Rest};
           }
         }
 
-        > .label-container {
+        & > .label-container {
           display: flex;
           align-items: center;
           justify-content: flex-start;
 
-          > .blr-label-switch-wrapper {
+          & > .blr-label-switch-wrapper {
             outline-offset: 2px;
             border-radius: 15px;
             position: relative;
@@ -44,7 +44,7 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
               outline: ${FocusBorder.width} ${FocusBorder.style} ${FocusBorder.color};
             }
 
-            > .blr-form-label-inline {
+            & > .blr-form-label-inline {
               color: ${LabelNextToControl.Rest};
             }
 
@@ -93,7 +93,7 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
               }
             }
 
-            > input {
+            & > input {
               appearance: none;
               outline-offset: 2px;
               border-radius: 15px;
@@ -103,7 +103,7 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
               }
             }
 
-            > .toggle-switch-slider {
+            & > .toggle-switch-slider {
               &::after {
                 content: "";
                 position: absolute;
@@ -113,11 +113,11 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
               }
             }
 
-            > input:checked + .toggle-switch-slider::after {
-              background-color: ${ToggleSwitch.Control.Ay11Icon.Selected.Fill.Rest};
+            & > input:checked + .toggle-switch-slider::after {
+              background-color: ${ToggleSwitch.Control.Foreground.Selected.Fill.Rest};
             }
 
-            > .toggle-switch-unselect {
+            & > .toggle-switch-unselect {
               &::after {
                 content: "";
                 position: absolute;
@@ -125,7 +125,7 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
               }
             }
 
-            > .toggle-switch-select {
+            & > .toggle-switch-select {
               &::after {
                 content: "";
                 position: absolute;
@@ -135,20 +135,20 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
             }
           }
 
-          > .blr-form-label-inline {
+          & > .blr-form-label-inline {
             color: ${LabelNextToControl.Rest};
           }
         }
 
         &.disabled {
-          > .toggle-content-col {
-            > .blr-form-label-inline {
+          & > .toggle-content-col {
+            & > .blr-form-label-inline {
               color: ${LabelNextToControl.Disabled};
             }
           }
 
-          > .label-container {
-            > .blr-form-label-inline {
+          & > .label-container {
+            & > .blr-form-label-inline {
               color: ${LabelNextToControl.Disabled};
             }
           }
@@ -161,8 +161,8 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
             }
           }
 
-          > .label-container {
-            > .blr-form-label-inline {
+          & > .label-container {
+            & > .blr-form-label-inline {
               color: ${LabelNextToControl.ReadOnly};
             }
           }
@@ -172,24 +172,24 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
           gap: ${ToggleSwitch.SM.Gap};
           width: 200px;
 
-          > .toggle-content-col {
+          & > .toggle-content-col {
             gap: ${ToggleSwitch.SM.ContentColGap};
           }
 
-          > .label-container {
+          & > .label-container {
             gap: ${ToggleSwitch.Control.SM.LabelGap};
 
-            > .blr-label-switch-wrapper {
+            & > .blr-label-switch-wrapper {
               width: ${ToggleSwitch.Control.SM.Background.Width};
               height: ${ToggleSwitch.Control.SM.Background.Height};
 
-              > input {
+              & > input {
                 width: ${ToggleSwitch.Control.SM.Background.Width};
                 height: ${ToggleSwitch.Control.SM.Background.Height};
                 margin: 0;
               }
 
-              > .toggle-switch-slider {
+              & > .toggle-switch-slider {
                 &::after {
                   width: ${ToggleSwitch.Control.SM.Knob.Sizing};
                   height: ${ToggleSwitch.Control.SM.Knob.Sizing};
@@ -198,11 +198,11 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
                 }
               }
 
-              > input:checked + .toggle-switch-slider::after {
+              & > input:checked + .toggle-switch-slider::after {
                 transform: translateX(16px);
               }
 
-              > .toggle-switch-unselect {
+              & > .toggle-switch-unselect {
                 &::after {
                   top: 7px;
                   left: 9px;
@@ -211,7 +211,7 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
                 }
               }
 
-              > .toggle-switch-select {
+              & > .toggle-switch-select {
                 &::after {
                   top: 7px;
                   right: 8px;
@@ -227,24 +227,24 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
           gap: ${ToggleSwitch.MD.Gap};
           width: 220px;
 
-          > .toggle-content-col {
+          & > .toggle-content-col {
             gap: ${ToggleSwitch.MD.ContentColGap};
           }
 
-          > .label-container {
+          & > .label-container {
             gap: ${ToggleSwitch.Control.MD.LabelGap};
 
-            > .blr-label-switch-wrapper {
+            & > .blr-label-switch-wrapper {
               width: ${ToggleSwitch.Control.MD.Background.Width};
               height: ${ToggleSwitch.Control.MD.Background.Height};
 
-              > input {
+              & > input {
                 width: ${ToggleSwitch.Control.MD.Background.Width};
                 height: ${ToggleSwitch.Control.MD.Background.Height};
                 margin: 0;
               }
 
-              > .toggle-switch-slider {
+              & > .toggle-switch-slider {
                 &::after {
                   width: ${ToggleSwitch.Control.MD.Knob.Sizing};
                   height: ${ToggleSwitch.Control.MD.Knob.Sizing};
@@ -253,11 +253,11 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
                 }
               }
 
-              > input:checked + .toggle-switch-slider::after {
+              & > input:checked + .toggle-switch-slider::after {
                 transform: translateX(20px);
               }
 
-              > .toggle-switch-unselect {
+              & > .toggle-switch-unselect {
                 &::after {
                   top: 8px;
                   left: 10px;
@@ -266,7 +266,7 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
                 }
               }
 
-              > .toggle-switch-select {
+              & > .toggle-switch-select {
                 &::after {
                   top: 8px;
                   right: 8px;
@@ -282,24 +282,24 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
           gap: ${ToggleSwitch.LG.Gap};
           width: 240px;
 
-          > .toggle-content-col {
+          & > .toggle-content-col {
             gap: ${ToggleSwitch.LG.ContentColGap};
           }
 
-          > .label-container {
+          & > .label-container {
             gap: ${ToggleSwitch.Control.LG.LabelGap};
 
-            > .blr-label-switch-wrapper {
+            & > .blr-label-switch-wrapper {
               width: ${ToggleSwitch.Control.LG.Background.Width};
               height: ${ToggleSwitch.Control.LG.Background.Height};
 
-              > input {
+              & > input {
                 width: ${ToggleSwitch.Control.LG.Background.Width};
                 height: ${ToggleSwitch.Control.LG.Background.Height};
                 margin: 0;
               }
 
-              > .toggle-switch-slider {
+              & > .toggle-switch-slider {
                 &::after {
                   width: ${ToggleSwitch.Control.LG.Knob.Sizing};
                   height: ${ToggleSwitch.Control.LG.Knob.Sizing};
@@ -308,11 +308,11 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
                 }
               }
 
-              > input:checked + .toggle-switch-slider::after {
+              & > input:checked + .toggle-switch-slider::after {
                 transform: translateX(23px);
               }
 
-              > .toggle-switch-unselect {
+              & > .toggle-switch-unselect {
                 &::after {
                   top: 9px;
                   left: 13px;
@@ -321,7 +321,7 @@ export const { tokenizedLight: toggleSwitchLight, tokenizedDark: toggleSwitchDar
                 }
               }
 
-              > .toggle-switch-select {
+              & > .toggle-switch-select {
                 &::after {
                   top: 9px;
                   right: 9px;

--- a/packages/ui-library/src/foundation/semantic-tokens/action.css.js
+++ b/packages/ui-library/src/foundation/semantic-tokens/action.css.js
@@ -10,162 +10,162 @@ export const { tokenizedLight: actionLight, tokenizedDark: actionDark } = render
       .blr-semantic-action {
         border-radius: ${BorderRadius};
         border-width: ${CTA.Rest.width};
-      }
 
-      .blr-semantic-action.cta {
-        background-color: ${CTA.SurfaceFill.Rest};
-        border-color: ${CTA.SurfaceStroke.Rest};
-        color: ${CTA.Icon.Rest};
-      }
+        &.xs {
+          font-family: ${XS.Label.fontFamily}, sans-serif;
+          font-weight: ${XS.Label.fontWeight};
+          line-height: ${XS.Label.lineHeight};
+          font-size: ${XS.Label.fontSize};
+        }
 
-      .blr-semantic-action.cta:hover {
-        background-color: ${CTA.SurfaceFill.Hover};
-      }
+        &.sm {
+          font-family: ${SM.Label.fontFamily}, sans-serif;
+          font-weight: ${SM.Label.fontWeight};
+          line-height: ${SM.Label.lineHeight};
+          font-size: ${SM.Label.fontSize};
+        }
 
-      .blr-semantic-action.cta:active {
-        background-color: ${CTA.SurfaceFill.Pressed};
-      }
+        &.md {
+          font-family: ${MD.Label.fontFamily}, sans-serif;
+          font-weight: ${MD.Label.fontWeight};
+          line-height: ${MD.Label.lineHeight};
+          font-size: ${MD.Label.fontSize};
+        }
 
-      .blr-semantic-action.cta:disabled {
-        background-color: ${CTA.SurfaceFill.Disabled};
-        color: ${CTA.Icon.Disabled};
-      }
+        &.lg {
+          font-family: ${LG.Label.fontFamily}, sans-serif;
+          font-weight: ${LG.Label.fontWeight};
+          line-height: ${LG.Label.lineHeight};
+          font-size: ${LG.Label.fontSize};
+        }
 
-      .blr-semantic-action.primary {
-        background-color: ${Primary.SurfaceFill.Rest};
-        border-color: ${Primary.SurfaceStroke.Rest};
-        color: ${Primary.Icon.Rest};
-      }
+        &.xl {
+          font-family: ${XL.Label.fontFamily}, sans-serif;
+          font-weight: ${XL.Label.fontWeight};
+          line-height: ${XL.Label.lineHeight};
+          font-size: ${XL.Label.fontSize};
+        }
 
-      .blr-semantic-action.primary:hover {
-        background-color: ${Primary.SurfaceFill.Hover};
-      }
+        &.cta {
+          background-color: ${CTA.SurfaceFill.Rest};
+          border-color: ${CTA.SurfaceStroke.Rest};
+          color: ${CTA.Icon.Rest};
 
-      .blr-semantic-action.primary:active {
-        background-color: ${Primary.SurfaceFill.Pressed};
-      }
+          &:hover {
+            background-color: ${CTA.SurfaceFill.Hover};
+          }
 
-      .blr-semantic-action.primary:disabled {
-        background-color: ${Primary.SurfaceFill.Disabled};
-        color: ${Primary.Icon.Disabled};
-      }
+          &:active {
+            background-color: ${CTA.SurfaceFill.Pressed};
+          }
 
-      .blr-semantic-action.secondary {
-        background-color: ${Secondary.SurfaceFill.Rest};
-        border-color: ${Secondary.SurfaceStroke.Rest};
-        color: ${Secondary.Icon.Rest};
-      }
+          &:disabled {
+            background-color: ${CTA.SurfaceFill.Disabled};
+            color: ${CTA.Icon.Disabled};
+          }
+        }
 
-      .blr-semantic-action.secondary:hover {
-        background-color: ${Secondary.SurfaceFill.Hover};
-        border-color: ${Secondary.SurfaceStroke.Hover};
-        color: ${Secondary.Icon.Hover};
-      }
+        &.primary {
+          background-color: ${Primary.SurfaceFill.Rest};
+          border-color: ${Primary.SurfaceStroke.Rest};
+          color: ${Primary.Icon.Rest};
 
-      .blr-semantic-action.secondary:active {
-        background-color: ${Secondary.SurfaceFill.Pressed};
-        border-color: ${Secondary.SurfaceStroke.Pressed};
-        color: ${Secondary.Icon.Pressed};
-      }
+          &:hover {
+            background-color: ${Primary.SurfaceFill.Hover};
+          }
 
-      .blr-semantic-action.secondary:disabled {
-        background-color: ${Secondary.SurfaceFill.Disabled};
-        border-color: ${Secondary.SurfaceStroke.Disabled};
-        color: ${Secondary.Icon.Disabled};
-      }
+          &:active {
+            background-color: ${Primary.SurfaceFill.Pressed};
+          }
 
-      .blr-semantic-action.silent {
-        background-color: ${Silent.SurfaceFill.Rest};
-        border-color: ${Silent.SurfaceStroke.Rest};
-        color: ${Silent.Icon.Rest};
-      }
+          &:disabled {
+            background-color: ${Primary.SurfaceFill.Disabled};
+            color: ${Primary.Icon.Disabled};
+          }
+        }
 
-      .blr-semantic-action.silent:hover {
-        background-color: ${Silent.SurfaceFill.Hover};
-        color: ${Silent.Icon.Hover};
-      }
+        &.secondary {
+          background-color: ${Secondary.SurfaceFill.Rest};
+          border-color: ${Secondary.SurfaceStroke.Rest};
+          color: ${Secondary.Icon.Rest};
 
-      .blr-semantic-action.silent:active {
-        background-color: ${Silent.SurfaceFill.Pressed};
-        color: ${Silent.Icon.Pressed};
-      }
+          &:hover {
+            background-color: ${Secondary.SurfaceFill.Hover};
+            border-color: ${Secondary.SurfaceStroke.Hover};
+            color: ${Secondary.Icon.Hover};
+          }
 
-      .blr-semantic-action.silent:disabled {
-        background-color: ${Silent.SurfaceFill.Pressed};
-        color: ${Silent.Icon.Disabled};
-      }
+          &:active {
+            background-color: ${Secondary.SurfaceFill.Pressed};
+            border-color: ${Secondary.SurfaceStroke.Pressed};
+            color: ${Secondary.Icon.Pressed};
+          }
 
-      .blr-semantic-action.xs {
-        font-family: ${XS.Label.fontFamily}, sans-serif;
-        font-weight: ${XS.Label.fontWeight};
-        line-height: ${XS.Label.lineHeight};
-        font-size: ${XS.Label.fontSize};
-      }
+          &:disabled {
+            background-color: ${Secondary.SurfaceFill.Disabled};
+            border-color: ${Secondary.SurfaceStroke.Disabled};
+            color: ${Secondary.Icon.Disabled};
+          }
+        }
 
-      .blr-semantic-action.sm {
-        font-family: ${SM.Label.fontFamily}, sans-serif;
-        font-weight: ${SM.Label.fontWeight};
-        line-height: ${SM.Label.lineHeight};
-        font-size: ${SM.Label.fontSize};
-      }
+        &.silent {
+          background-color: ${Silent.SurfaceFill.Rest};
+          border-color: ${Silent.SurfaceStroke.Rest};
+          color: ${Silent.Icon.Rest};
 
-      .blr-semantic-action.md {
-        font-family: ${MD.Label.fontFamily}, sans-serif;
-        font-weight: ${MD.Label.fontWeight};
-        line-height: ${MD.Label.lineHeight};
-        font-size: ${MD.Label.fontSize};
-      }
+          &:hover {
+            background-color: ${Silent.SurfaceFill.Hover};
+            color: ${Silent.Icon.Hover};
+          }
 
-      .blr-semantic-action.lg {
-        font-family: ${LG.Label.fontFamily}, sans-serif;
-        font-weight: ${LG.Label.fontWeight};
-        line-height: ${LG.Label.lineHeight};
-        font-size: ${LG.Label.fontSize};
-      }
+          &:active {
+            background-color: ${Silent.SurfaceFill.Pressed};
+            color: ${Silent.Icon.Pressed};
+          }
 
-      .blr-semantic-action.xl {
-        font-family: ${XL.Label.fontFamily}, sans-serif;
-        font-weight: ${XL.Label.fontWeight};
-        line-height: ${XL.Label.lineHeight};
-        font-size: ${XL.Label.fontSize};
-      }
+          &:disabled {
+            background-color: ${Silent.SurfaceFill.Pressed};
+            color: ${Silent.Icon.Disabled};
+          }
+        }
 
-      .blr-semantic-action.destructive {
-        background-color: ${Destructive.SurfaceFill.Rest};
-        border-color: ${Destructive.SurfaceStroke.Rest};
-        color: ${Destructive.Icon.Rest};
-      }
+        &.destructive {
+          background-color: ${Destructive.SurfaceFill.Rest};
+          border-color: ${Destructive.SurfaceStroke.Rest};
+          color: ${Destructive.Icon.Rest};
 
-      .blr-semantic-action.destructive:hover {
-        background-color: ${Destructive.SurfaceFill.Hover};
-      }
+          &:hover {
+            background-color: ${Destructive.SurfaceFill.Hover};
+          }
 
-      .blr-semantic-action.destructive:active {
-        background-color: ${Destructive.SurfaceFill.Pressed};
-      }
+          &:active {
+            background-color: ${Destructive.SurfaceFill.Pressed};
+          }
 
-      .blr-semantic-action.destructive:disabled {
-        background-color: ${Destructive.SurfaceFill.Disabled};
-        color: ${Destructive.Icon.Disabled};
-      }
+          &:disabled {
+            background-color: ${Destructive.SurfaceFill.Disabled};
+            color: ${Destructive.Icon.Disabled};
+          }
+        }
 
-      .blr-semantic-action.encourage {
-        background-color: ${Encourage.SurfaceFill.Rest};
-        border-color: ${Encourage.SurfaceStroke.Rest};
-        color: ${Encourage.Icon.Rest};
-      }
+        &.encourage {
+          background-color: ${Encourage.SurfaceFill.Rest};
+          border-color: ${Encourage.SurfaceStroke.Rest};
+          color: ${Encourage.Icon.Rest};
 
-      .blr-semantic-action.encourage:hover {
-        background-color: ${Encourage.SurfaceFill.Hover};
-      }
+          &:hover {
+            background-color: ${Encourage.SurfaceFill.Hover};
+          }
 
-      .blr-semantic-action.encourage:active {
-        background-color: ${Encourage.SurfaceFill.Pressed};
-      }
+          &:active {
+            background-color: ${Encourage.SurfaceFill.Pressed};
+          }
 
-      .blr-semantic-action.encourage:disabled {
-        background-color: ${Encourage.SurfaceFill.Disabled};
-        color: ${Encourage.Icon.Disabled};
+          &:disabled {
+            background-color: ${Encourage.SurfaceFill.Disabled};
+            color: ${Encourage.Icon.Disabled};
+          }
+        }
       }
     `;
   }


### PR DESCRIPTION
please have close look at these syntax errors :) 

dont use " > .peter"
please use "& > .peter"

dont use ":not(.ursula, .gerhard)"
please use ":not(.ursula):not(.gerhard)"

dont use "import { css } from "lit";"
please use "import { css } from "nested-css-to-flat/lit-css";"

dont use "+ .ruediger"
please use "& + . ruediger"

with these changes many major firefox issues have been solved. (especially on radio)
but yet, there is work left on safari. 

please also try to test with these browsers more often :) 