### PR TITLE
button with focus ring in safari

### DIFF
--- a/packages/ui-library/src/components/icon-button/index.css.ts
+++ b/packages/ui-library/src/components/icon-button/index.css.ts
@@ -5,7 +5,7 @@ export const styleCustom = css`
     all: inital;
     align-items: center;
     justify-content: center;
-    display: inline-block;
+    display: inline-flex;
     cursor: pointer;
   }
 

--- a/packages/ui-library/src/components/icon-button/index.test.ts
+++ b/packages/ui-library/src/components/icon-button/index.test.ts
@@ -19,7 +19,7 @@ describe('blr-icon-button', () => {
   it('is having a button containing the right className', async () => {
     const element = await fixture(BlrIconButtonRenderFunction(sampleParams));
 
-    const button = querySelectorDeep('button', element.getRootNode() as HTMLElement);
+    const button = querySelectorDeep('span', element.getRootNode() as HTMLElement);
     const className = button?.className;
 
     expect(className).to.contain('blr-icon-button');

--- a/packages/ui-library/src/components/icon-button/index.ts
+++ b/packages/ui-library/src/components/icon-button/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { LitElement, html, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { IconType } from '@boiler/icons';
 import { styleCustom } from './index.css';
 import { actionDark, actionLight } from '../../foundation/semantic-tokens/action.css';

--- a/packages/ui-library/src/components/text-button/index.css.ts
+++ b/packages/ui-library/src/components/text-button/index.css.ts
@@ -2,8 +2,10 @@ import { css } from "nested-css-to-flat/lit-css";
 
 export const styleCustom = css`
   .blr-text-button {
+    all: inital;
     align-items: center;
-    display: flex;
+    justify-content: center;
+    display: inline-flex;
     cursor: pointer;
     outline-offset: -2px;
   }

--- a/packages/ui-library/src/components/text-button/index.test.ts
+++ b/packages/ui-library/src/components/text-button/index.test.ts
@@ -19,7 +19,7 @@ describe('blr-text-button', () => {
   it('is having a button containing the right className', async () => {
     const element = await fixture(BlrTextButtonRenderFunction(sampleParams));
 
-    const button = querySelectorDeep('button', element.getRootNode() as HTMLElement);
+    const button = querySelectorDeep('span', element.getRootNode() as HTMLElement);
     const className = button?.className;
 
     expect(className).to.contain('blr-text-button');

--- a/packages/ui-library/src/components/text-button/index.ts
+++ b/packages/ui-library/src/components/text-button/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { LitElement, html, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property } from 'lit/decorators.js';
@@ -30,6 +31,14 @@ export class BlrTextButton extends LitElement {
 
   @property() theme: ThemeType = 'Light';
 
+  protected handleFocus = () => {
+    console.log('focused');
+  };
+
+  protected handleBlur = () => {
+    console.log('blurred');
+  };
+
   protected render() {
     const dynamicStyles = this.theme === 'Light' ? [actionLight, textButtonLight] : [actionDark, textButtonDark];
 
@@ -43,10 +52,14 @@ export class BlrTextButton extends LitElement {
     return html`<style>
         ${dynamicStyles.map((style) => style)}
       </style>
-      <button
+      <span
         class="blr-semantic-action blr-text-button ${classes}"
         @click="${this.onClick}"
-        @blur="${this.onBlur}"
+        tabindex="0"
+        @focus=${this.handleFocus}
+        @blur=${this.handleBlur}
+        role="button"
+        @keydown=${this.onClick}
         ?disabled="${this.disabled}"
         id=${this.buttonId || nothing}
       >
@@ -72,7 +85,7 @@ export class BlrTextButton extends LitElement {
                 hideAria: true,
               })}`}
             `}
-      </button>`;
+      </span>`;
   }
 }
 


### PR DESCRIPTION
Found a way to get focus working in safari even using the regular :focus instead of custom class. 

important: since i switched from html button to span it is important for screenreaders to have the role="button" attribute and also to handle keydown event as click. 

keep in mind this button appears to be a bit taller. that needs to be fixed but other then that, this could be the way to go here (to fix safari)

if we want to display focused buttons in storybook, we still would need a custom class and a property to activate that from the outside. but that was not the target of this PR