### PR TITLE
Feat/error variant for label

### DIFF
--- a/packages/ui-library/src/components/internal-components/form-label/index.stories.ts
+++ b/packages/ui-library/src/components/internal-components/form-label/index.stories.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { Themes } from '../../../foundation/_tokens-generated/index.themes';
-import { FormSizes } from '../../../globals/constants';
+import { FormSizes, LabelVariants } from '../../../globals/constants';
 import { BlrFormLabelRenderFunction, BlrFormLabelType } from './index';
 
 import './index';
@@ -16,14 +16,18 @@ export default {
       options: Themes,
       control: { type: 'select' },
     },
+    variant: {
+      options: LabelVariants,
+      control: { type: 'select' },
+    },
   },
   parameters: {
     viewMode: 'docs',
   },
 };
 
-export const BlrFormLabel = ({ labelText, labelAppendix, labelSize, forValue, theme }: BlrFormLabelType) =>
-  BlrFormLabelRenderFunction({ labelText, labelAppendix, labelSize, forValue, theme });
+export const BlrFormLabel = ({ labelText, labelAppendix, labelSize, forValue, theme, variant }: BlrFormLabelType) =>
+  BlrFormLabelRenderFunction({ labelText, labelAppendix, labelSize, forValue, theme, variant });
 
 BlrFormLabel.storyName = 'BlrFormLabel';
 
@@ -33,4 +37,5 @@ BlrFormLabel.args = {
   labelAppendix: 'added',
   labelSize: 'md',
   forValue: 'Richard',
+  variant: 'label',
 };

--- a/packages/ui-library/src/components/internal-components/form-label/index.ts
+++ b/packages/ui-library/src/components/internal-components/form-label/index.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, nothing } from 'lit';
-import { InputSizesType } from '../../../globals/types';
+import { InputSizesType, LabelVariantType } from '../../../globals/types';
 import { formDark, formLight } from '../../../foundation/semantic-tokens/form.css';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit-html/directives/class-map.js';
@@ -14,6 +14,7 @@ export class BlrFormLabel extends LitElement {
   @property() labelSize: InputSizesType = 'md';
   @property() forValue: string | undefined;
   @property() theme: ThemeType = 'Light';
+  @property() variant: LabelVariantType = 'label';
 
   protected render() {
     const dynamicStyles = this.theme === 'Light' ? [formLight] : [formDark];
@@ -21,6 +22,7 @@ export class BlrFormLabel extends LitElement {
     const labelClasses = classMap({
       'blr-form-label': true,
       [`${this.labelSize}`]: this.labelSize,
+      [`${this.variant}`]: this.variant,
     });
 
     const spanClasses = classMap({
@@ -46,6 +48,7 @@ export const BlrFormLabelRenderFunction = ({
   labelSize,
   forValue,
   theme,
+  variant,
 }: BlrFormLabelType) => {
   return html`<blr-form-label
     .labelText=${labelText}
@@ -53,5 +56,6 @@ export const BlrFormLabelRenderFunction = ({
     .labelSize=${labelSize}
     .forValue=${forValue}
     .theme=${theme}
+    .variant=${variant}
   ></blr-form-hint>`;
 };

--- a/packages/ui-library/src/components/number-input/index.ts
+++ b/packages/ui-library/src/components/number-input/index.ts
@@ -180,6 +180,7 @@ export class BlrNumberInput extends LitElement {
             labelAppendix: this.labelAppendix,
             forValue: this.numberInputId,
             theme: this.theme,
+            variant: this.hasError ? 'error' : 'label',
           })}`
         : nothing}
       <div class="${wrapperClasses}">

--- a/packages/ui-library/src/components/select/index.ts
+++ b/packages/ui-library/src/components/select/index.ts
@@ -95,6 +95,7 @@ export class BlrSelect extends LitElement {
               labelSize: this.size,
               forValue: this.selectId,
               theme: this.theme,
+              variant: this.hasError ? 'error' : 'label',
             })
           : nothing}
         <div class="blr-select-inner-container ${inputClasses}">

--- a/packages/ui-library/src/components/text-input/index.ts
+++ b/packages/ui-library/src/components/text-input/index.ts
@@ -95,13 +95,16 @@ export class BlrTextInput extends LitElement {
       </style>
       <div class="blr-text-input ${classes}">
         ${this.hasLabel
-          ? html` ${BlrFormLabelRenderFunction({
-              labelText: this.label,
-              labelSize: this.size,
-              labelAppendix: this.labelAppendix,
-              forValue: this.textInputId,
-              theme: this.theme,
-            })}`
+          ? html`
+              ${BlrFormLabelRenderFunction({
+                labelText: this.label,
+                labelSize: this.size,
+                labelAppendix: this.labelAppendix,
+                forValue: this.textInputId,
+                theme: this.theme,
+                variant: this.hasError ? 'error' : 'label',
+              })}
+            `
           : html``}
         <div class="blr-input-inner-container ${inputContainerClasses}">
           <div class="blr-input-wrapper">

--- a/packages/ui-library/src/components/textarea/index.ts
+++ b/packages/ui-library/src/components/textarea/index.ts
@@ -122,6 +122,7 @@ export class BlrTextarea extends LitElement {
             labelAppendix: this.labelAppendix,
             forValue: this.textareaId,
             theme: this.theme,
+            variant: this.hasError ? 'error' : 'label',
           })}
         </div>
         <div class="input-wrapper">

--- a/packages/ui-library/src/foundation/semantic-tokens/form.css.js
+++ b/packages/ui-library/src/foundation/semantic-tokens/form.css.js
@@ -381,6 +381,14 @@ export const { tokenizedLight: formLight, tokenizedDark: formDark } = renderThem
         color: ${Label.ReadOnly};
       }
 
+      &.error {
+        color: ${Label.Error};
+
+        .blr-form-label-appendix {
+          color: ${LabelAppendix.Error};
+        }
+      }
+
       &.sm {
         padding: ${SM.LabelSlot.Padding};
         font-weight: ${SM.Label.fontWeight};
@@ -389,6 +397,10 @@ export const { tokenizedLight: formLight, tokenizedDark: formDark } = renderThem
         line-height: ${SM.Label.lineHeight};
         gap: ${SM.LabelComponent.ItemSpacing};
         color: ${Label.Rest};
+
+        &.error {
+          color: ${Label.Error};
+        }
       }
 
       &.md {
@@ -408,6 +420,10 @@ export const { tokenizedLight: formLight, tokenizedDark: formDark } = renderThem
         line-height: ${LG.Label.lineHeight};
         color: ${Label.Rest};
         gap: ${LG.LabelComponent.ItemSpacing};
+
+        &.error {
+          color: ${Label.Error};
+        }
       }
     }
 
@@ -461,7 +477,7 @@ export const { tokenizedLight: formLight, tokenizedDark: formDark } = renderThem
       }
 
       .error {
-        color: ${Caption.Error};
+        color: ${Label.Error};
       }
 
       .hint {

--- a/packages/ui-library/src/globals/constants.ts
+++ b/packages/ui-library/src/globals/constants.ts
@@ -28,3 +28,5 @@ export const ButtonsAlignmentVariants = ['flex-start', 'center', 'flex-end'] as 
 export const ToolTipVisibility = ['onLoad', 'onHover'] as const;
 export const ToolTipPosition = ['left', 'right', 'top', 'bottom'] as const;
 export const ToolTipArrowPosition = ['start', 'end', 'middle', 'hide'] as const;
+
+export const LabelVariants = ['label', 'error'] as const;

--- a/packages/ui-library/src/globals/types.ts
+++ b/packages/ui-library/src/globals/types.ts
@@ -16,6 +16,7 @@ import {
   OverflowVariantsStandard,
   OverflowVariantsFullWidth,
   ButtonGroupSizes,
+  LabelVariants,
 } from './constants';
 
 export type SizesType = (typeof Sizes)[number];
@@ -74,3 +75,5 @@ export type ButtonOption = {
 export type ToolTipPosition = 'left' | 'right' | 'top' | 'bottom';
 export type ToolTipVisibility = 'onLoad' | 'onHover';
 export type ToolTipArrowPosition = 'start' | 'end' | 'middle' | 'hide';
+
+export type LabelVariantType = (typeof LabelVariants)[number];


### PR DESCRIPTION
As per our conversation with Lars, error state color has been introduced to label in error state.

I have added a variant for label component as the error color in error state of label is the same for all the components. If the hasError is true, the variant adds a an error class which turns the label and its appendix to red.