### PR TITLE
Fix/add missing padding loader

### DIFF
--- a/packages/ui-library/src/components/feedback/loader/index.css.ts
+++ b/packages/ui-library/src/components/feedback/loader/index.css.ts
@@ -31,22 +31,33 @@ export const { tokenizedLight: styleCustomLight, tokenizedDark: styleCustomDark 
       &.sm {
         width: ${Loader.Container.Size.SM};
         height: ${Loader.Container.Size.SM};
-        padding: ${Loader.Container.Padding.SM};
         border-width: ${Loader.Background.BorderWidth.SM};
       }
 
       &.md {
         width: ${Loader.Container.Size.MD};
         height: ${Loader.Container.Size.MD};
-        padding: ${Loader.Container.Padding.MD};
         border-width: ${Loader.Background.BorderWidth.MD};
       }
 
       &.lg {
         width: ${Loader.Container.Size.LG};
         height: ${Loader.Container.Size.LG};
-        padding: ${Loader.Container.Padding.LG};
         border-width: ${Loader.Background.BorderWidth.LG};
+      }
+    }
+
+    .loader-container {
+      &.sm {
+        padding: ${Loader.Container.Padding.SM};
+      }
+
+      &.md {
+        padding: ${Loader.Container.Padding.MD};
+      }
+
+      &.lg {
+        padding: ${Loader.Container.Padding.LG};
       }
     }
 

--- a/packages/ui-library/src/components/feedback/loader/index.ts
+++ b/packages/ui-library/src/components/feedback/loader/index.ts
@@ -31,7 +31,9 @@ export class BlrLoader extends LitElement {
       return html`<style>
           ${dynamicStyles.map((style) => style)}
         </style>
-        <div class="${classes}" role="status" aria-live="polite" ?aria-label=${this.loadingStatus}></div>`;
+        <div class="loader-container ${this.size}">
+          <div class="${classes}" role="status" aria-live="polite" ?aria-label=${this.loadingStatus}></div>
+        </div>`;
     }
   }
 }


### PR DESCRIPTION
Ticket [Loader - add missing padding to loader and remove wrong sizes#576](https://github.com/deven-org/B01LER-Kitchen/issues/576)

I have moved the padding out of blr-loader and place it in a container as `box-sizing: border-box `property of blr-loader was overwriting the padding. 