### PR TITLE
Fix: Text Area - Counter gets left-aligned if hasError=true #1064 

### DIFF
--- a/packages/ui-library/src/components/textarea/index.css.ts
+++ b/packages/ui-library/src/components/textarea/index.css.ts
@@ -44,9 +44,11 @@ export const styleCustom = typeSafeNestedCss`
 
     &.hint, &.error {
       justify-content: right;
+    }
 
-    &.sm      justify-content: space-between;
-    margin: ${captionslot.margin.sm};
+    &.sm {
+      & > blr-counter {
+        margin: ${captionslot.margin.sm};
       }
     }
 

--- a/packages/ui-library/src/components/textarea/index.css.ts
+++ b/packages/ui-library/src/components/textarea/index.css.ts
@@ -43,12 +43,10 @@ export const styleCustom = typeSafeNestedCss`
     justify-content: right;
 
     &.hint, &.error {
-      justify-content: space-between;
-    }
+      justify-content: right;
 
-    &.sm {
-      & > blr-counter {
-        margin: ${captionslot.margin.sm};
+    &.sm      justify-content: space-between;
+    margin: ${captionslot.margin.sm};
       }
     }
 


### PR DESCRIPTION
Fixes #1064 


![image](https://github.com/deven-org/boiler/assets/109983860/c2604ba9-98f2-45a6-a399-e6b282b16e67)
