### PR TITLE
fix(ci): fix ci package install

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Install yarn 4
-        run: yarn set version 4.x
-
       - name: Install modules
         run: yarn
 

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Install yarn 4
-        run: yarn set version 4.x
-
       - name: Install modules
         run: yarn
 

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Install yarn 4
-        run: yarn set version 4.x
-
       - name: Install modules
         run: yarn
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Install yarn 4
-        run: yarn set version 4.x
-
       - name: Install modules
         run: yarn
 


### PR DESCRIPTION
## CI Pipeline Fix
Apparently yarn just released version 4.1.1 which calculates some package checksums differently than before.
This made all workflows fail during the install phase. To align the yarn versions used in the CI pipeline and in local development, i removed the yarn set version 4.x step from all relevant workflows. corepack will use whatever yarn binary is stored in our repo / configured in our .yarnrc automatically.