### PR TITLE
fix(ui-library): radio group size fix (#1139)

### DIFF
--- a/packages/ui-library/src/components/radio-group/index.ts
+++ b/packages/ui-library/src/components/radio-group/index.ts
@@ -99,6 +99,7 @@ export class BlrRadioGroup extends LitElementCustom {
       item.disabled = this.disabled;
       item.readonly = this.readonly;
       item.theme = this.theme;
+      item.sizeVariant = this.sizeVariant;
 
       this._radioCheckedSignalSubscriptionDisposers.push(
         item.signals.checked.subscribe((value) => this.handleRadioCheckedSignal(item, value))


### PR DESCRIPTION
closes #1139 

Includes the fix for the bug related to size not changing in the radio-group.